### PR TITLE
Use BSD locks on macOS and Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Request a process level lock on a file, resolving when the lock is granted. If a
 
 To lock only a portion of the file, `offset` and `length` may be passed. A `length` of `0` will request a lock from `offset` to the end of the file.
 
+On macOS, BSD locks are used and so only locks on the whole file are supported.
+
+On Linux, open file description locks are used and require a kernel version >= 3.15.
+
 Note that the lock is only advisory and there is nothing stopping another process from accessing the file by simply ignoring the lock.
 
 Options include:

--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@ Request a process level lock on a file, resolving when the lock is granted. If a
 
 To lock only a portion of the file, `offset` and `length` may be passed. A `length` of `0` will request a lock from `offset` to the end of the file.
 
-On macOS, BSD locks are used and so only locks on the whole file are supported.
-
-On Linux, open file description locks are used and require a kernel version >= 3.15.
+On macOS and Linux, BSD locks are used and so only locks on the whole file are supported.
 
 Note that the lock is only advisory and there is nothing stopping another process from accessing the file by simply ignoring the lock.
 

--- a/src/linux.c
+++ b/src/linux.c
@@ -1,3 +1,5 @@
+#define _GNU_SOURCE
+
 #include <errno.h>
 #include <fcntl.h>
 #include <linux/falloc.h>

--- a/src/linux.c
+++ b/src/linux.c
@@ -9,51 +9,6 @@
 #include "platform.h"
 
 int
-fsctl__lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type) {
-  struct flock data = {
-    .l_start = offset,
-    .l_len = length,
-    .l_pid = 0,
-    .l_type = type == FSCTL_WRLOCK ? F_WRLCK : F_RDLCK,
-    .l_whence = SEEK_SET,
-  };
-
-  int res = fcntl(fd, F_OFD_SETLKW, &data);
-
-  return res == -1 ? uv_translate_sys_error(errno) : res;
-}
-
-int
-fsctl__try_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type) {
-  struct flock data = {
-    .l_start = offset,
-    .l_len = length,
-    .l_pid = 0,
-    .l_type = type == FSCTL_WRLOCK ? F_WRLCK : F_RDLCK,
-    .l_whence = SEEK_SET,
-  };
-
-  int res = fcntl(fd, F_OFD_SETLK, &data);
-
-  return res == -1 ? uv_translate_sys_error(errno) : res;
-}
-
-int
-fsctl__unlock (uv_os_fd_t fd, uint64_t offset, size_t length) {
-  struct flock data = {
-    .l_start = offset,
-    .l_len = length,
-    .l_pid = 0,
-    .l_type = F_UNLCK,
-    .l_whence = SEEK_SET,
-  };
-
-  int res = fcntl(fd, F_OFD_SETLK, &data);
-
-  return res == -1 ? uv_translate_sys_error(errno) : res;
-}
-
-int
 fsctl__punch_hole (uv_os_fd_t fd, uint64_t offset, size_t length) {
   int res = fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, offset, length);
 

--- a/src/linux.c
+++ b/src/linux.c
@@ -8,6 +8,51 @@
 #include "platform.h"
 
 int
+fsctl__lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type) {
+  struct flock data = {
+    .l_start = offset,
+    .l_len = length,
+    .l_pid = 0,
+    .l_type = type == FSCTL_WRLOCK ? F_WRLCK : F_RDLCK,
+    .l_whence = SEEK_SET,
+  };
+
+  int res = fcntl(fd, F_OFD_SETLKW, &data);
+
+  return res == -1 ? uv_translate_sys_error(errno) : res;
+}
+
+int
+fsctl__try_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type) {
+  struct flock data = {
+    .l_start = offset,
+    .l_len = length,
+    .l_pid = 0,
+    .l_type = type == FSCTL_WRLOCK ? F_WRLCK : F_RDLCK,
+    .l_whence = SEEK_SET,
+  };
+
+  int res = fcntl(fd, F_OFD_SETLK, &data);
+
+  return res == -1 ? uv_translate_sys_error(errno) : res;
+}
+
+int
+fsctl__unlock (uv_os_fd_t fd, uint64_t offset, size_t length) {
+  struct flock data = {
+    .l_start = offset,
+    .l_len = length,
+    .l_pid = 0,
+    .l_type = F_UNLCK,
+    .l_whence = SEEK_SET,
+  };
+
+  int res = fcntl(fd, F_OFD_SETLK, &data);
+
+  return res == -1 ? uv_translate_sys_error(errno) : res;
+}
+
+int
 fsctl__punch_hole (uv_os_fd_t fd, uint64_t offset, size_t length) {
   int res = fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, offset, length);
 

--- a/src/linux.c
+++ b/src/linux.c
@@ -2,7 +2,6 @@
 
 #include <errno.h>
 #include <fcntl.h>
-#include <linux/falloc.h>
 #include <stdint.h>
 #include <uv.h>
 

--- a/src/mac.c
+++ b/src/mac.c
@@ -7,6 +7,51 @@
 #include "platform.h"
 
 int
+fsctl__lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type) {
+  struct flock data = {
+    .l_start = offset,
+    .l_len = length,
+    .l_pid = 0,
+    .l_type = type == FSCTL_WRLOCK ? F_WRLCK : F_RDLCK,
+    .l_whence = SEEK_SET,
+  };
+
+  int res = fcntl(fd, F_SETLKW, &data);
+
+  return res == -1 ? uv_translate_sys_error(errno) : res;
+}
+
+int
+fsctl__try_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type) {
+  struct flock data = {
+    .l_start = offset,
+    .l_len = length,
+    .l_pid = 0,
+    .l_type = type == FSCTL_WRLOCK ? F_WRLCK : F_RDLCK,
+    .l_whence = SEEK_SET,
+  };
+
+  int res = fcntl(fd, F_SETLK, &data);
+
+  return res == -1 ? uv_translate_sys_error(errno) : res;
+}
+
+int
+fsctl__unlock (uv_os_fd_t fd, uint64_t offset, size_t length) {
+  struct flock data = {
+    .l_start = offset,
+    .l_len = length,
+    .l_pid = 0,
+    .l_type = F_UNLCK,
+    .l_whence = SEEK_SET,
+  };
+
+  int res = fcntl(fd, F_SETLK, &data);
+
+  return res == -1 ? uv_translate_sys_error(errno) : res;
+}
+
+int
 fsctl__punch_hole (uv_os_fd_t fd, uint64_t offset, size_t length) {
   struct fpunchhole data = {
     .fp_flags = 0,

--- a/src/mac.c
+++ b/src/mac.c
@@ -8,45 +8,27 @@
 
 int
 fsctl__lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type) {
-  struct flock data = {
-    .l_start = offset,
-    .l_len = length,
-    .l_pid = 0,
-    .l_type = type == FSCTL_WRLOCK ? F_WRLCK : F_RDLCK,
-    .l_whence = SEEK_SET,
-  };
+  if (offset != 0 || length != 0) return UV_EINVAL;
 
-  int res = fcntl(fd, F_SETLKW, &data);
+  int res = flock(fd, type == FSCTL_WRLOCK ? LOCK_EX : LOCK_SH);
 
   return res == -1 ? uv_translate_sys_error(errno) : res;
 }
 
 int
 fsctl__try_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type) {
-  struct flock data = {
-    .l_start = offset,
-    .l_len = length,
-    .l_pid = 0,
-    .l_type = type == FSCTL_WRLOCK ? F_WRLCK : F_RDLCK,
-    .l_whence = SEEK_SET,
-  };
+  if (offset != 0 || length != 0) return UV_EINVAL;
 
-  int res = fcntl(fd, F_SETLK, &data);
+  int res = flock(fd, (type == FSCTL_WRLOCK ? LOCK_EX : LOCK_SH) | LOCK_NB);
 
   return res == -1 ? uv_translate_sys_error(errno) : res;
 }
 
 int
 fsctl__unlock (uv_os_fd_t fd, uint64_t offset, size_t length) {
-  struct flock data = {
-    .l_start = offset,
-    .l_len = length,
-    .l_pid = 0,
-    .l_type = F_UNLCK,
-    .l_whence = SEEK_SET,
-  };
+  if (offset != 0 || length != 0) return UV_EINVAL;
 
-  int res = fcntl(fd, F_SETLK, &data);
+  int res = flock(fd, LOCK_UN);
 
   return res == -1 ? uv_translate_sys_error(errno) : res;
 }

--- a/src/mac.c
+++ b/src/mac.c
@@ -7,33 +7,6 @@
 #include "platform.h"
 
 int
-fsctl__lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type) {
-  if (offset != 0 || length != 0) return UV_EINVAL;
-
-  int res = flock(fd, type == FSCTL_WRLOCK ? LOCK_EX : LOCK_SH);
-
-  return res == -1 ? uv_translate_sys_error(errno) : res;
-}
-
-int
-fsctl__try_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type) {
-  if (offset != 0 || length != 0) return UV_EINVAL;
-
-  int res = flock(fd, (type == FSCTL_WRLOCK ? LOCK_EX : LOCK_SH) | LOCK_NB);
-
-  return res == -1 ? uv_translate_sys_error(errno) : res;
-}
-
-int
-fsctl__unlock (uv_os_fd_t fd, uint64_t offset, size_t length) {
-  if (offset != 0 || length != 0) return UV_EINVAL;
-
-  int res = flock(fd, LOCK_UN);
-
-  return res == -1 ? uv_translate_sys_error(errno) : res;
-}
-
-int
 fsctl__punch_hole (uv_os_fd_t fd, uint64_t offset, size_t length) {
   struct fpunchhole data = {
     .fp_flags = 0,

--- a/src/posix.c
+++ b/src/posix.c
@@ -1,7 +1,37 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
 #include <uv.h>
 
 #include "../include/fsctl.h"
 #include "platform.h"
+
+int
+fsctl__lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type) {
+  if (offset != 0 || length != 0) return UV_EINVAL;
+
+  int res = flock(fd, type == FSCTL_WRLOCK ? LOCK_EX : LOCK_SH);
+
+  return res == -1 ? uv_translate_sys_error(errno) : res;
+}
+
+int
+fsctl__try_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type) {
+  if (offset != 0 || length != 0) return UV_EINVAL;
+
+  int res = flock(fd, (type == FSCTL_WRLOCK ? LOCK_EX : LOCK_SH) | LOCK_NB);
+
+  return res == -1 ? uv_translate_sys_error(errno) : res;
+}
+
+int
+fsctl__unlock (uv_os_fd_t fd, uint64_t offset, size_t length) {
+  if (offset != 0 || length != 0) return UV_EINVAL;
+
+  int res = flock(fd, LOCK_UN);
+
+  return res == -1 ? uv_translate_sys_error(errno) : res;
+}
 
 int
 fsctl__sparse (uv_os_fd_t fd) {

--- a/src/posix.c
+++ b/src/posix.c
@@ -1,55 +1,7 @@
-#include <errno.h>
-#include <fcntl.h>
-#include <stdint.h>
 #include <uv.h>
 
 #include "../include/fsctl.h"
 #include "platform.h"
-
-int
-fsctl__lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type) {
-  struct flock data = {
-    .l_start = offset,
-    .l_len = length,
-    .l_pid = 0,
-    .l_type = type == FSCTL_WRLOCK ? F_WRLCK : F_RDLCK,
-    .l_whence = SEEK_SET,
-  };
-
-  int res = fcntl(fd, F_SETLKW, &data);
-
-  return res == -1 ? uv_translate_sys_error(errno) : res;
-}
-
-int
-fsctl__try_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type) {
-  struct flock data = {
-    .l_start = offset,
-    .l_len = length,
-    .l_pid = 0,
-    .l_type = type == FSCTL_WRLOCK ? F_WRLCK : F_RDLCK,
-    .l_whence = SEEK_SET,
-  };
-
-  int res = fcntl(fd, F_SETLK, &data);
-
-  return res == -1 ? uv_translate_sys_error(errno) : res;
-}
-
-int
-fsctl__unlock (uv_os_fd_t fd, uint64_t offset, size_t length) {
-  struct flock data = {
-    .l_start = offset,
-    .l_len = length,
-    .l_pid = 0,
-    .l_type = F_UNLCK,
-    .l_whence = SEEK_SET,
-  };
-
-  int res = fcntl(fd, F_SETLK, &data);
-
-  return res == -1 ? uv_translate_sys_error(errno) : res;
-}
 
 int
 fsctl__sparse (uv_os_fd_t fd) {

--- a/test/lock.mjs
+++ b/test/lock.mjs
@@ -2,6 +2,7 @@ import test from 'brittle'
 import { fork } from 'child_process'
 import { open } from 'fs/promises'
 import { temporaryFile } from 'tempy'
+import { lock } from '../index.js'
 
 test('2 shared + 1 exclusive lock', async (t) => {
   const shared = t.test('grant shared locks')
@@ -57,4 +58,18 @@ test('2 shared + 1 exclusive lock', async (t) => {
   p3.kill()
 
   await handle.close()
+})
+
+test('2 shared + 1 exclusive lock, same process', async (t) => {
+  const file = temporaryFile()
+
+  const a = await open(file, 'w+')
+  const b = await open(file, 'w+')
+  const c = await open(file, 'w+')
+
+  await lock(a.fd)
+  await lock(b.fd)
+  await lock(c.fd, { exclusive: true })
+
+  t.pass()
 })

--- a/test/lock.mjs
+++ b/test/lock.mjs
@@ -14,7 +14,7 @@ test('2 exclusive locks, same fd', async (t) => {
   t.ok(tryLock(handle.fd, { exclusive: true }), 'lock granted')
 })
 
-test('2 exclusive locks, separate fd', async (t) => {
+test('2 exclusive locks, separate fd', { skip: process.platform === 'darwin' }, async (t) => {
   const file = temporaryFile()
 
   const a = await open(file, 'w+')
@@ -38,7 +38,7 @@ test('2 shared locks + 1 exclusive lock, same fd', async (t) => {
   t.ok(tryLock(handle.fd, { exclusive: true }), 'lock granted')
 })
 
-test('2 shared locks + 1 exclusive lock, separate fd', async (t) => {
+test('2 shared locks + 1 exclusive lock, separate fd', { skip: process.platform === 'darwin' }, async (t) => {
   const file = temporaryFile()
 
   const a = await open(file, 'w+')

--- a/test/lock.mjs
+++ b/test/lock.mjs
@@ -4,6 +4,9 @@ import { open } from 'fs/promises'
 import { temporaryFile } from 'tempy'
 import { tryLock, unlock } from '../index.js'
 
+const isDarwin = process.platform === 'darwin'
+const isWindows = process.platform === 'win32'
+
 test('2 exclusive locks, same fd', async (t) => {
   const file = temporaryFile()
 
@@ -11,10 +14,15 @@ test('2 exclusive locks, same fd', async (t) => {
   t.teardown(() => handle.close())
 
   t.ok(tryLock(handle.fd, { exclusive: true }), 'lock granted')
-  t.ok(tryLock(handle.fd, { exclusive: true }), 'lock granted')
+
+  if (isWindows) {
+    t.absent(tryLock(handle.fd, { exclusive: true }), 'lock denied')
+  } else {
+    t.ok(tryLock(handle.fd, { exclusive: true }), 'lock granted')
+  }
 })
 
-test('2 exclusive locks, separate fd', { skip: process.platform === 'darwin' }, async (t) => {
+test('2 exclusive locks, separate fd', async (t) => {
   const file = temporaryFile()
 
   const a = await open(file, 'w+')
@@ -24,7 +32,12 @@ test('2 exclusive locks, separate fd', { skip: process.platform === 'darwin' }, 
   t.teardown(() => b.close())
 
   t.ok(tryLock(a.fd, { exclusive: true }), 'lock granted')
-  t.absent(tryLock(b.fd, { exclusive: true }), 'lock denied')
+
+  if (isDarwin) {
+    t.ok(tryLock(b.fd, { exclusive: true }), 'lock granted')
+  } else {
+    t.absent(tryLock(b.fd, { exclusive: true }), 'lock denied')
+  }
 })
 
 test('2 shared locks + 1 exclusive lock, same fd', async (t) => {
@@ -35,10 +48,15 @@ test('2 shared locks + 1 exclusive lock, same fd', async (t) => {
 
   t.ok(tryLock(handle.fd), 'lock granted')
   t.ok(tryLock(handle.fd), 'lock granted')
-  t.ok(tryLock(handle.fd, { exclusive: true }), 'lock granted')
+
+  if (isWindows) {
+    t.absent(tryLock(handle.fd, { exclusive: true }), 'lock denied')
+  } else {
+    t.ok(tryLock(handle.fd, { exclusive: true }), 'lock granted')
+  }
 })
 
-test('2 shared locks + 1 exclusive lock, separate fd', { skip: process.platform === 'darwin' }, async (t) => {
+test('2 shared locks + 1 exclusive lock, separate fd', async (t) => {
   const file = temporaryFile()
 
   const a = await open(file, 'w+')
@@ -53,7 +71,11 @@ test('2 shared locks + 1 exclusive lock, separate fd', { skip: process.platform 
   t.ok(tryLock(a.fd), 'lock granted')
   t.ok(tryLock(b.fd), 'lock granted')
 
-  t.absent(tryLock(c.fd, { exclusive: true }), 'lock denied')
+  if (isDarwin) {
+    t.ok(tryLock(c.fd, { exclusive: true }), 'lock granted')
+  } else {
+    t.absent(tryLock(c.fd, { exclusive: true }), 'lock denied')
+  }
 
   unlock(a.fd)
   unlock(b.fd)

--- a/test/lock.mjs
+++ b/test/lock.mjs
@@ -2,7 +2,7 @@ import test from 'brittle'
 import { fork } from 'child_process'
 import { open } from 'fs/promises'
 import { temporaryFile } from 'tempy'
-import { lock, tryLock, unlock } from '../index.js'
+import { tryLock, unlock } from '../index.js'
 
 test('2 exclusive locks, same fd', async (t) => {
   const file = temporaryFile()
@@ -115,23 +115,4 @@ test('2 shared locks + 1 exclusive lock, separate process', async (t) => {
   p3.kill()
 
   await handle.close()
-})
-
-test('atomic swap', async (t) => {
-  const file = temporaryFile()
-
-  const a = await open(file, 'w+')
-  t.teardown(() => a.close())
-
-  const b = await open(file, 'w+')
-  t.teardown(() => b.close())
-
-  t.ok(tryLock(a.fd), 'lock granted')
-
-  const p = lock(b.fd, { exclusive: true })
-
-  await lock(a.fd, { exclusive: true })
-  unlock(a.fd)
-
-  await p
 })

--- a/test/lock.mjs
+++ b/test/lock.mjs
@@ -4,7 +4,6 @@ import { open } from 'fs/promises'
 import { temporaryFile } from 'tempy'
 import { tryLock, unlock } from '../index.js'
 
-const isDarwin = process.platform === 'darwin'
 const isWindows = process.platform === 'win32'
 
 test('2 exclusive locks, same fd', async (t) => {
@@ -32,12 +31,7 @@ test('2 exclusive locks, separate fd', async (t) => {
   t.teardown(() => b.close())
 
   t.ok(tryLock(a.fd, { exclusive: true }), 'lock granted')
-
-  if (isDarwin) {
-    t.ok(tryLock(b.fd, { exclusive: true }), 'lock granted')
-  } else {
-    t.absent(tryLock(b.fd, { exclusive: true }), 'lock denied')
-  }
+  t.absent(tryLock(b.fd, { exclusive: true }), 'lock denied')
 })
 
 test('2 shared locks + 1 exclusive lock, same fd', async (t) => {
@@ -71,11 +65,7 @@ test('2 shared locks + 1 exclusive lock, separate fd', async (t) => {
   t.ok(tryLock(a.fd), 'lock granted')
   t.ok(tryLock(b.fd), 'lock granted')
 
-  if (isDarwin) {
-    t.ok(tryLock(c.fd, { exclusive: true }), 'lock granted')
-  } else {
-    t.absent(tryLock(c.fd, { exclusive: true }), 'lock denied')
-  }
+  t.absent(tryLock(c.fd, { exclusive: true }), 'lock denied')
 
   unlock(a.fd)
   unlock(b.fd)


### PR DESCRIPTION
Standard POSIX locks operate on an `(inode, pid)` pair and are released when *any* file descriptor for a file is closed by a process. A lock therefore risks being unexpectedly released if *any* operation within a process closes a file descriptor for which the process currently holds a lock.

While this is nicely solved by OFD locks in Linux, these are only available in 3.15. I've therefore had to fall back to BSD locks on macOS, as Darwin has no equivalent to OFD locks, and Linux.