### PR TITLE
Add lock upgrade/downgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,26 @@ Request a process level lock on a file, returning `true` if the lock was granted
 
 Options are the same as `fsctl.lock()`.
 
+#### `await fsctl.downgradeLock(fd[, offset[, length]])`
+
+Request a downgrade from an already held exclusive lock to a shared lock.
+
+On Windows, the downgrade will happen atomically.
+
+#### `const granted = fsctl.tryDowngradeLock(fd[, offset[, length]])`
+
+Request a downgrade from an already held exclusive lock to a shared lock, returning `true` if the lock was granted or `false` if another process currently holds the lock. If `false` is returned, the exclusive lock is lost and must be requested again.
+
+On Windows, the downgrade will happen atomically.
+
+#### `await fsctl.upgradeLock(fd[, offset[, length]])`
+
+Request an upgrade from an already held shared lock to an exclusive lock.
+
+#### `const granted = fsctl.tryUpgradeLock(fd[, offset[, length]])`
+
+Request an upgrade from an already held shared lock to an exclusive lock, returning `true` if the lock was granted or `false` if another process currently holds the lock. If `false` is returned, the shared lock is lost and must be requested again.
+
 #### `fsctl.unlock(fd[, offset[, length]])`
 
 Release a process level lock on a file.

--- a/README.md
+++ b/README.md
@@ -55,25 +55,25 @@ Request a lock on a file, resolving when the lock is granted. If another file de
 
 Options are the same as `fsctl.lock()`.
 
-#### `await fsctl.downgradeLock(fd[, offset[, length]])`
-
-Request a downgrade from an already held exclusive lock to a shared lock.
-
-On Windows, the downgrade will happen atomically.
-
 #### `const granted = fsctl.tryDowngradeLock(fd[, offset[, length]])`
 
 Request a downgrade from an already held exclusive lock to a shared lock, returning `true` if the lock was granted or `false` if another process currently holds the lock. If `false` is returned, the exclusive lock is lost and must be requested again.
 
-On Windows, the downgrade will happen atomically.
+On Windows, the downgrade will happen atomically and be immediately granted.
 
-#### `await fsctl.upgradeLock(fd[, offset[, length]])`
+#### `await fsctl.waitForDowngradeLock(fd[, offset[, length]])`
 
-Request an upgrade from an already held shared lock to an exclusive lock.
+Request a downgrade from an already held exclusive lock to a shared lock.
+
+On Windows, the downgrade will happen atomically and be immediately granted.
 
 #### `const granted = fsctl.tryUpgradeLock(fd[, offset[, length]])`
 
 Request an upgrade from an already held shared lock to an exclusive lock, returning `true` if the lock was granted or `false` if another process currently holds the lock. If `false` is returned, the shared lock is lost and must be requested again.
+
+#### `await fsctl.waitForUpgradeLock(fd[, offset[, length]])`
+
+Request an upgrade from an already held shared lock to an exclusive lock.
 
 #### `fsctl.unlock(fd[, offset[, length]])`
 

--- a/binding.c
+++ b/binding.c
@@ -156,6 +156,82 @@ NAPI_METHOD(fsctl_napi_try_lock) {
   NAPI_RETURN_INT32(err);
 }
 
+NAPI_METHOD(fsctl_napi_downgrade_lock) {
+  NAPI_ARGV(6)
+  NAPI_ARGV_BUFFER_CAST(fsctl_napi_lock_t *, req, 0)
+  NAPI_ARGV_UINT32(fd, 1)
+  NAPI_ARGV_UINT32(offset, 2)
+  NAPI_ARGV_UINT32(length, 3)
+
+  req->env = env;
+
+  napi_create_reference(env, argv[4], 1, &(req->ctx));
+  napi_create_reference(env, argv[5], 1, &(req->cb));
+
+  uv_loop_t *loop;
+  napi_get_uv_event_loop(env, &loop);
+
+  int err = fsctl_downgrade_lock(
+    loop,
+    (fsctl_lock_t *) req,
+    uv_get_osfhandle(fd),
+    offset,
+    length,
+    on_fsctl_lock
+  );
+
+  NAPI_RETURN_INT32(err);
+}
+
+NAPI_METHOD(fsctl_napi_try_downgrade_lock) {
+  NAPI_ARGV(3)
+  NAPI_ARGV_UINT32(fd, 0)
+  NAPI_ARGV_UINT32(offset, 1)
+  NAPI_ARGV_UINT32(len, 2)
+
+  int err = fsctl_try_downgrade_lock(uv_get_osfhandle(fd), offset, len);
+
+  NAPI_RETURN_INT32(err);
+}
+
+NAPI_METHOD(fsctl_napi_upgrade_lock) {
+  NAPI_ARGV(6)
+  NAPI_ARGV_BUFFER_CAST(fsctl_napi_lock_t *, req, 0)
+  NAPI_ARGV_UINT32(fd, 1)
+  NAPI_ARGV_UINT32(offset, 2)
+  NAPI_ARGV_UINT32(length, 3)
+
+  req->env = env;
+
+  napi_create_reference(env, argv[4], 1, &(req->ctx));
+  napi_create_reference(env, argv[5], 1, &(req->cb));
+
+  uv_loop_t *loop;
+  napi_get_uv_event_loop(env, &loop);
+
+  int err = fsctl_upgrade_lock(
+    loop,
+    (fsctl_lock_t *) req,
+    uv_get_osfhandle(fd),
+    offset,
+    length,
+    on_fsctl_lock
+  );
+
+  NAPI_RETURN_INT32(err);
+}
+
+NAPI_METHOD(fsctl_napi_try_upgrade_lock) {
+  NAPI_ARGV(3)
+  NAPI_ARGV_UINT32(fd, 0)
+  NAPI_ARGV_UINT32(offset, 1)
+  NAPI_ARGV_UINT32(len, 2)
+
+  int err = fsctl_try_upgrade_lock(uv_get_osfhandle(fd), offset, len);
+
+  NAPI_RETURN_INT32(err);
+}
+
 NAPI_METHOD(fsctl_napi_unlock) {
   NAPI_ARGV(3)
   NAPI_ARGV_UINT32(fd, 0)
@@ -224,6 +300,10 @@ NAPI_INIT() {
 
   NAPI_EXPORT_FUNCTION(fsctl_napi_lock)
   NAPI_EXPORT_FUNCTION(fsctl_napi_try_lock)
+  NAPI_EXPORT_FUNCTION(fsctl_napi_downgrade_lock)
+  NAPI_EXPORT_FUNCTION(fsctl_napi_try_downgrade_lock)
+  NAPI_EXPORT_FUNCTION(fsctl_napi_upgrade_lock)
+  NAPI_EXPORT_FUNCTION(fsctl_napi_try_upgrade_lock)
   NAPI_EXPORT_FUNCTION(fsctl_napi_unlock)
   NAPI_EXPORT_FUNCTION(fsctl_napi_punch_hole)
   NAPI_EXPORT_FUNCTION(fsctl_napi_sparse)

--- a/include/fsctl.h
+++ b/include/fsctl.h
@@ -73,16 +73,16 @@ int
 fsctl_wait_for_lock (uv_loop_t *loop, fsctl_lock_t *req, uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type, fsctl_lock_cb cb);
 
 int
-fsctl_downgrade_lock (uv_loop_t *loop, fsctl_lock_t *req, uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_cb cb);
-
-int
 fsctl_try_downgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length);
 
 int
-fsctl_upgrade_lock (uv_loop_t *loop, fsctl_lock_t *req, uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_cb cb);
+fsctl_wait_for_downgrade_lock (uv_loop_t *loop, fsctl_lock_t *req, uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_cb cb);
 
 int
 fsctl_try_upgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length);
+
+int
+fsctl_wait_for_upgrade_lock (uv_loop_t *loop, fsctl_lock_t *req, uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_cb cb);
 
 int
 fsctl_unlock (uv_os_fd_t fd, uint64_t offset, size_t length);

--- a/include/fsctl.h
+++ b/include/fsctl.h
@@ -73,6 +73,18 @@ int
 fsctl_try_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type);
 
 int
+fsctl_downgrade_lock (uv_loop_t *loop, fsctl_lock_t *req, uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_cb cb);
+
+int
+fsctl_try_downgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length);
+
+int
+fsctl_upgrade_lock (uv_loop_t *loop, fsctl_lock_t *req, uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_cb cb);
+
+int
+fsctl_try_upgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length);
+
+int
 fsctl_unlock (uv_os_fd_t fd, uint64_t offset, size_t length);
 
 int

--- a/index.js
+++ b/index.js
@@ -69,26 +69,6 @@ exports.waitForLock = function waitForLock (fd, offset = 0, length = 0, opts = {
   return promise
 }
 
-exports.downgradeLock = function downgradeLock (fd, offset = 0, length = 0) {
-  const req = Buffer.alloc(binding.sizeof_fsctl_napi_lock_t)
-  const ctx = {
-    req,
-    resolve: null,
-    reject: null
-  }
-
-  const promise = new Promise((resolve, reject) => {
-    ctx.resolve = resolve
-    ctx.reject = reject
-  })
-
-  const errno = binding.fsctl_napi_downgrade_lock(req, fd, offset, length, ctx, onwork)
-
-  if (errno < 0) return Promise.reject(toError(errno))
-
-  return promise
-}
-
 exports.tryDowngradeLock = function tryDowngradeLock (fd, offset = 0, length = 0) {
   const errno = binding.fsctl_napi_try_downgrade_lock(fd, offset, length)
 
@@ -101,7 +81,7 @@ exports.tryDowngradeLock = function tryDowngradeLock (fd, offset = 0, length = 0
   return true
 }
 
-exports.upgradeLock = function upgradeLock (fd, offset = 0, length = 0) {
+exports.waitForDowngradeLock = function downgradeLock (fd, offset = 0, length = 0) {
   const req = Buffer.alloc(binding.sizeof_fsctl_napi_lock_t)
   const ctx = {
     req,
@@ -114,7 +94,7 @@ exports.upgradeLock = function upgradeLock (fd, offset = 0, length = 0) {
     ctx.reject = reject
   })
 
-  const errno = binding.fsctl_napi_upgrade_lock(req, fd, offset, length, ctx, onwork)
+  const errno = binding.fsctl_napi_wait_for_downgrade_lock(req, fd, offset, length, ctx, onwork)
 
   if (errno < 0) return Promise.reject(toError(errno))
 
@@ -131,6 +111,26 @@ exports.tryUpgradeLock = function tryUpgradeLock (fd, offset = 0, length = 0) {
   }
 
   return true
+}
+
+exports.waitForUpgradeLock = function upgradeLock (fd, offset = 0, length = 0) {
+  const req = Buffer.alloc(binding.sizeof_fsctl_napi_lock_t)
+  const ctx = {
+    req,
+    resolve: null,
+    reject: null
+  }
+
+  const promise = new Promise((resolve, reject) => {
+    ctx.resolve = resolve
+    ctx.reject = reject
+  })
+
+  const errno = binding.fsctl_napi_wait_for_upgrade_lock(req, fd, offset, length, ctx, onwork)
+
+  if (errno < 0) return Promise.reject(toError(errno))
+
+  return promise
 }
 
 exports.unlock = function unlock (fd, offset = 0, length = 0) {

--- a/index.js
+++ b/index.js
@@ -66,6 +66,70 @@ exports.tryLock = function tryLock (fd, offset = 0, length = 0, opts = {}) {
   return true
 }
 
+exports.downgradeLock = function downgradeLock (fd, offset = 0, length = 0) {
+  const req = Buffer.alloc(binding.sizeof_fsctl_napi_lock_t)
+  const ctx = {
+    req,
+    resolve: null,
+    reject: null
+  }
+
+  const promise = new Promise((resolve, reject) => {
+    ctx.resolve = resolve
+    ctx.reject = reject
+  })
+
+  const errno = binding.fsctl_napi_downgrade_lock(req, fd, offset, length, ctx, onwork)
+
+  if (errno < 0) return Promise.reject(toError(errno))
+
+  return promise
+}
+
+exports.tryDowngradeLock = function tryDowngradeLock (fd, offset = 0, length = 0) {
+  const errno = binding.fsctl_napi_try_downgrade_lock(fd, offset, length)
+
+  if (errno < 0) {
+    const err = toError(errno)
+    if (err.code === 'EAGAIN') return false
+    throw err
+  }
+
+  return true
+}
+
+exports.upgradeLock = function upgradeLock (fd, offset = 0, length = 0) {
+  const req = Buffer.alloc(binding.sizeof_fsctl_napi_lock_t)
+  const ctx = {
+    req,
+    resolve: null,
+    reject: null
+  }
+
+  const promise = new Promise((resolve, reject) => {
+    ctx.resolve = resolve
+    ctx.reject = reject
+  })
+
+  const errno = binding.fsctl_napi_upgrade_lock(req, fd, offset, length, ctx, onwork)
+
+  if (errno < 0) return Promise.reject(toError(errno))
+
+  return promise
+}
+
+exports.tryUpgradeLock = function tryUpgradeLock (fd, offset = 0, length = 0) {
+  const errno = binding.fsctl_napi_try_upgrade_lock(fd, offset, length)
+
+  if (errno < 0) {
+    const err = toError(errno)
+    if (err.code === 'EAGAIN') return false
+    throw err
+  }
+
+  return true
+}
+
 exports.unlock = function unlock (fd, offset = 0, length = 0) {
   const errno = binding.fsctl_napi_unlock(fd, offset, length)
 

--- a/src/platform.h
+++ b/src/platform.h
@@ -13,16 +13,16 @@ int
 fsctl__wait_for_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type);
 
 int
-fsctl__downgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length);
-
-int
 fsctl__try_downgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length);
 
 int
-fsctl__upgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length);
+fsctl__wait_for_downgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length);
 
 int
 fsctl__try_upgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length);
+
+int
+fsctl__wait_for_upgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length);
 
 int
 fsctl__unlock (uv_os_fd_t fd, uint64_t offset, size_t length);

--- a/src/platform.h
+++ b/src/platform.h
@@ -13,6 +13,18 @@ int
 fsctl__try_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type);
 
 int
+fsctl__downgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length);
+
+int
+fsctl__try_downgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length);
+
+int
+fsctl__upgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length);
+
+int
+fsctl__try_upgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length);
+
+int
 fsctl__unlock (uv_os_fd_t fd, uint64_t offset, size_t length);
 
 int

--- a/src/posix.c
+++ b/src/posix.c
@@ -25,6 +25,26 @@ fsctl__try_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_
 }
 
 int
+fsctl__downgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length) {
+  return fsctl__lock(fd, offset, length, FSCTL_RDLOCK);
+}
+
+int
+fsctl__try_downgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length) {
+  return fsctl__try_lock(fd, offset, length, FSCTL_RDLOCK);
+}
+
+int
+fsctl__upgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length) {
+  return fsctl__lock(fd, offset, length, FSCTL_WRLOCK);
+}
+
+int
+fsctl__try_upgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length) {
+  return fsctl__try_lock(fd, offset, length, FSCTL_WRLOCK);
+}
+
+int
 fsctl__unlock (uv_os_fd_t fd, uint64_t offset, size_t length) {
   if (offset != 0 || length != 0) return UV_EINVAL;
 

--- a/src/posix.c
+++ b/src/posix.c
@@ -25,23 +25,23 @@ fsctl__wait_for_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_
 }
 
 int
-fsctl__downgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length) {
-  return fsctl__lock(fd, offset, length, FSCTL_RDLOCK);
-}
-
-int
 fsctl__try_downgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length) {
   return fsctl__try_lock(fd, offset, length, FSCTL_RDLOCK);
 }
 
 int
-fsctl__upgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length) {
-  return fsctl__lock(fd, offset, length, FSCTL_WRLOCK);
+fsctl__wait_for_downgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length) {
+  return fsctl__wait_for_lock(fd, offset, length, FSCTL_RDLOCK);
 }
 
 int
 fsctl__try_upgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length) {
   return fsctl__try_lock(fd, offset, length, FSCTL_WRLOCK);
+}
+
+int
+fsctl__wait_for_upgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length) {
+  return fsctl__wait_for_lock(fd, offset, length, FSCTL_WRLOCK);
 }
 
 int

--- a/src/shared.c
+++ b/src/shared.c
@@ -56,7 +56,7 @@ static void
 fsctl__downgrade_lock_work (uv_work_t *req) {
   fsctl_lock_t *r = (fsctl_lock_t *) req->data;
 
-  r->result = fsctl__downgrade_lock(r->fd, r->offset, r->length);
+  r->result = fsctl__wait_for_downgrade_lock(r->fd, r->offset, r->length);
 }
 
 int
@@ -75,7 +75,7 @@ static void
 fsctl__upgrade_lock_work (uv_work_t *req) {
   fsctl_lock_t *r = (fsctl_lock_t *) req->data;
 
-  r->result = fsctl__upgrade_lock(r->fd, r->offset, r->length);
+  r->result = fsctl__wait_for_upgrade_lock(r->fd, r->offset, r->length);
 }
 
 int

--- a/src/win.c
+++ b/src/win.c
@@ -58,14 +58,6 @@ fsctl__wait_for_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_
 }
 
 int
-fsctl__downgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length) {
-  int res = fsctl__lock(fd, offset, length, FSCTL_RDLOCK);
-  if (res < 0) return res;
-
-  return fsctl__unlock(fd, offset, length);
-}
-
-int
 fsctl__try_downgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length) {
   int res = fsctl__try_lock(fd, offset, length, FSCTL_RDLOCK);
   if (res < 0) return res;
@@ -74,11 +66,11 @@ fsctl__try_downgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length) {
 }
 
 int
-fsctl__upgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length) {
-  int res = fsctl__unlock(fd, offset, length);
+fsctl__wait_for_downgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length) {
+  int res = fsctl__wait_for_lock(fd, offset, length, FSCTL_RDLOCK);
   if (res < 0) return res;
 
-  return fsctl__lock(fd, offset, length, FSCTL_WRLOCK);
+  return fsctl__unlock(fd, offset, length);
 }
 
 int
@@ -87,6 +79,14 @@ fsctl__try_upgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length) {
   if (res < 0) return res;
 
   return fsctl__try_lock(fd, offset, length, FSCTL_WRLOCK);
+}
+
+int
+fsctl__wait_for_upgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length) {
+  int res = fsctl__unlock(fd, offset, length);
+  if (res < 0) return res;
+
+  return fsctl__wait_for_lock(fd, offset, length, FSCTL_WRLOCK);
 }
 
 int

--- a/src/win.c
+++ b/src/win.c
@@ -58,6 +58,38 @@ fsctl__try_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_
 }
 
 int
+fsctl__downgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length) {
+  int res = fsctl__lock(fd, offset, length, FSCTL_RDLOCK);
+  if (res < 0) return res;
+
+  return fsctl__unlock(fd, offset, length);
+}
+
+int
+fsctl__try_downgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length) {
+  int res = fsctl__try_lock(fd, offset, length, FSCTL_RDLOCK);
+  if (res < 0) return res;
+
+  return fsctl__unlock(fd, offset, length);
+}
+
+int
+fsctl__upgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length) {
+  int res = fsctl__unlock(fd, offset, length);
+  if (res < 0) return res;
+
+  return fsctl__lock(fd, offset, length, FSCTL_WRLOCK);
+}
+
+int
+fsctl__try_upgrade_lock (uv_os_fd_t fd, uint64_t offset, size_t length) {
+  int res = fsctl__unlock(fd, offset, length);
+  if (res < 0) return res;
+
+  return fsctl__try_lock(fd, offset, length, FSCTL_WRLOCK);
+}
+
+int
 fsctl__unlock (uv_os_fd_t fd, uint64_t offset, size_t length) {
   if (length == 0) length = SIZE_MAX;
 


### PR DESCRIPTION
On POSIX, locks can be upgraded and downgraded by simply requesting a new lock. On Windows, however, upgrades and downgrades have to happen in several steps, necessitating a dedicated API to encapsulate these operations.

When using POSIX locks, upgrades and downgrades happen atomically and so the existing lock won't be lost if the new lock cannot be granted. When using BSD locks, however, both upgrades and downgrades are equivalent to releasing the existing lock and requesting a new lock.

On Windows, only downgrades happen atomically by first requesting a shared lock and only when granted releasing the exclusive lock. Upgrades happen similar to BSD locks; release the existing lock and request a new lock.