### PR TITLE
Make lock API compatible with v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ try {
 
 ## API
 
-#### `const granted = fsctl.lock(fd[, offset[, length]][, options])`
+#### `const granted = fsctl.tryLock(fd[, offset[, length]][, options])`
 
 Request a lock on a file, returning `true` if the lock was granted or `false` if another file descriptor currently holds the lock.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ const { lock, unlock } = require('fsctl')
 
 const file = await open('file.txt', 'a+')
 
-await lock(file.fd, { exclusive: true })
+await waitForLock(file.fd, { exclusive: true })
 
 try {
   await file.write('hello world')
@@ -27,9 +27,9 @@ try {
 
 ## API
 
-#### `await fsctl.lock(fd[, offset[, length]][, options])`
+#### `const granted = fsctl.lock(fd[, offset[, length]][, options])`
 
-Request a process level lock on a file, resolving when the lock is granted. If another process holds the lock, the lock will not be granted until the other process either exits or releases the lock.
+Request a lock on a file, returning `true` if the lock was granted or `false` if another file descriptor currently holds the lock.
 
 To lock only a portion of the file, `offset` and `length` may be passed. A `length` of `0` will request a lock from `offset` to the end of the file.
 
@@ -41,24 +41,23 @@ Options include:
 
 ```js
 {
-  // If `true`, request an exclusive lock, i.e. a write lock, on the file. By
-  // default, a shared lock, i.e. a read lock, is requested.
+  // If `true`, request a shared lock, i.e. a read lock, on the file. By
+  // default, an exclusive lock, i.e. a write lock, is requested.
   // Be aware that an exclusive lock can only be granted to files that are
-  // writable! A request for an exclusive lock on a read-only file is ignored 
-  // and treated as a request for a shared lock.
-  exclusive: false
+  // writable!
+  shared: false
 }
 ```
 
-#### `const granted = fsctl.tryLock(fd[, offset[, length]][, options])`
+#### `await fsctl.waitForLock(fd[, offset[, length]][, options])`
 
-Request a process level lock on a file, returning `true` if the lock was granted or `false` if another process currently holds the lock.
+Request a lock on a file, resolving when the lock is granted. If another file descriptor holds the lock, the lock will not be granted until the other file descriptor releases the lock.
 
 Options are the same as `fsctl.lock()`.
 
 #### `fsctl.unlock(fd[, offset[, length]])`
 
-Release a process level lock on a file.
+Release a lock on a file.
 
 #### `await fsctl.punchHole(fd, offset, length)`
 

--- a/binding.c
+++ b/binding.c
@@ -110,7 +110,24 @@ on_fsctl_sparse (fsctl_sparse_t *req, int status) {
   napi_delete_reference(env, r->cb);
 }
 
-NAPI_METHOD(fsctl_napi_lock) {
+NAPI_METHOD(fsctl_napi_try_lock) {
+  NAPI_ARGV(4)
+  NAPI_ARGV_UINT32(fd, 0)
+  NAPI_ARGV_UINT32(offset, 1)
+  NAPI_ARGV_UINT32(len, 2)
+  NAPI_ARGV_UINT32(exclusive, 3)
+
+  int err = fsctl_try_lock(
+    uv_get_osfhandle(fd),
+    offset,
+    len,
+    exclusive ? FSCTL_WRLOCK : FSCTL_RDLOCK
+  );
+
+  NAPI_RETURN_INT32(err);
+}
+
+NAPI_METHOD(fsctl_napi_wait_for_lock) {
   NAPI_ARGV(7)
   NAPI_ARGV_BUFFER_CAST(fsctl_napi_lock_t *, req, 0)
   NAPI_ARGV_UINT32(fd, 1)
@@ -126,7 +143,7 @@ NAPI_METHOD(fsctl_napi_lock) {
   uv_loop_t *loop;
   napi_get_uv_event_loop(env, &loop);
 
-  int err = fsctl_lock(
+  int err = fsctl_wait_for_lock(
     loop,
     (fsctl_lock_t *) req,
     uv_get_osfhandle(fd),
@@ -134,23 +151,6 @@ NAPI_METHOD(fsctl_napi_lock) {
     length,
     exclusive ? FSCTL_WRLOCK : FSCTL_RDLOCK,
     on_fsctl_lock
-  );
-
-  NAPI_RETURN_INT32(err);
-}
-
-NAPI_METHOD(fsctl_napi_try_lock) {
-  NAPI_ARGV(4)
-  NAPI_ARGV_UINT32(fd, 0)
-  NAPI_ARGV_UINT32(offset, 1)
-  NAPI_ARGV_UINT32(len, 2)
-  NAPI_ARGV_UINT32(exclusive, 3)
-
-  int err = fsctl_try_lock(
-    uv_get_osfhandle(fd),
-    offset,
-    len,
-    exclusive ? FSCTL_WRLOCK : FSCTL_RDLOCK
   );
 
   NAPI_RETURN_INT32(err);
@@ -222,8 +222,8 @@ NAPI_INIT() {
   NAPI_EXPORT_SIZEOF(fsctl_napi_punch_hole_t)
   NAPI_EXPORT_SIZEOF(fsctl_napi_sparse_t)
 
-  NAPI_EXPORT_FUNCTION(fsctl_napi_lock)
   NAPI_EXPORT_FUNCTION(fsctl_napi_try_lock)
+  NAPI_EXPORT_FUNCTION(fsctl_napi_wait_for_lock)
   NAPI_EXPORT_FUNCTION(fsctl_napi_unlock)
   NAPI_EXPORT_FUNCTION(fsctl_napi_punch_hole)
   NAPI_EXPORT_FUNCTION(fsctl_napi_sparse)

--- a/include/fsctl.h
+++ b/include/fsctl.h
@@ -67,10 +67,10 @@ struct fsctl_sparse_s {
 };
 
 int
-fsctl_lock (uv_loop_t *loop, fsctl_lock_t *req, uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type, fsctl_lock_cb cb);
+fsctl_try_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type);
 
 int
-fsctl_try_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type);
+fsctl_wait_for_lock (uv_loop_t *loop, fsctl_lock_t *req, uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type, fsctl_lock_cb cb);
 
 int
 fsctl_unlock (uv_os_fd_t fd, uint64_t offset, size_t length);

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ function onwork (errno) {
   else this.resolve()
 }
 
-exports.lock = function lock (fd, offset = 0, length = 0, opts = {}) {
+exports.tryLock = function tryLock (fd, offset = 0, length = 0, opts = {}) {
   if (typeof offset === 'object') {
     opts = offset
     offset = 0
@@ -31,6 +31,9 @@ exports.lock = function lock (fd, offset = 0, length = 0, opts = {}) {
 
   return true
 }
+
+// Alias for backwards compatibility
+exports.lock = exports.tryLock
 
 exports.waitForLock = function waitForLock (fd, offset = 0, length = 0, opts = {}) {
   if (typeof offset === 'object') {
@@ -59,7 +62,7 @@ exports.waitForLock = function waitForLock (fd, offset = 0, length = 0, opts = {
     ctx.reject = reject
   })
 
-  const errno = binding.fsctl_napi_lock(req, fd, offset, length, opts.shared ? 0 : 1, ctx, onwork)
+  const errno = binding.fsctl_napi_wait_for_lock(req, fd, offset, length, opts.shared ? 0 : 1, ctx, onwork)
 
   if (errno < 0) return Promise.reject(toError(errno))
 

--- a/src/platform.h
+++ b/src/platform.h
@@ -7,10 +7,10 @@
 #include "../include/fsctl.h"
 
 int
-fsctl__lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type);
+fsctl__try_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type);
 
 int
-fsctl__try_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type);
+fsctl__wait_for_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type);
 
 int
 fsctl__unlock (uv_os_fd_t fd, uint64_t offset, size_t length);

--- a/src/posix.c
+++ b/src/posix.c
@@ -7,19 +7,19 @@
 #include "platform.h"
 
 int
-fsctl__lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type) {
+fsctl__try_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type) {
   if (offset != 0 || length != 0) return UV_EINVAL;
 
-  int res = flock(fd, type == FSCTL_WRLOCK ? LOCK_EX : LOCK_SH);
+  int res = flock(fd, (type == FSCTL_WRLOCK ? LOCK_EX : LOCK_SH) | LOCK_NB);
 
   return res == -1 ? uv_translate_sys_error(errno) : res;
 }
 
 int
-fsctl__try_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type) {
+fsctl__wait_for_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type) {
   if (offset != 0 || length != 0) return UV_EINVAL;
 
-  int res = flock(fd, (type == FSCTL_WRLOCK ? LOCK_EX : LOCK_SH) | LOCK_NB);
+  int res = flock(fd, type == FSCTL_WRLOCK ? LOCK_EX : LOCK_SH);
 
   return res == -1 ? uv_translate_sys_error(errno) : res;
 }

--- a/src/shared.c
+++ b/src/shared.c
@@ -4,11 +4,22 @@
 #include "../include/fsctl.h"
 #include "platform.h"
 
+int
+fsctl_try_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type) {
+  int err = fsctl__try_lock(fd, offset, length, type);
+
+  if (err == UV_EACCES || err == UV_EAGAIN || err == UV_EBUSY) {
+    err = UV_EAGAIN;
+  }
+
+  return err;
+}
+
 static void
 fsctl__lock_work (uv_work_t *req) {
   fsctl_lock_t *r = (fsctl_lock_t *) req->data;
 
-  r->result = fsctl__lock(r->fd, r->offset, r->length, r->type);
+  r->result = fsctl__wait_for_lock(r->fd, r->offset, r->length, r->type);
 }
 
 static void
@@ -19,7 +30,7 @@ fsctl__lock_after_work (uv_work_t *req, int status) {
 }
 
 int
-fsctl_lock (uv_loop_t *loop, fsctl_lock_t *req, uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type, fsctl_lock_cb cb) {
+fsctl_wait_for_lock (uv_loop_t *loop, fsctl_lock_t *req, uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type, fsctl_lock_cb cb) {
   req->fd = fd;
   req->offset = offset;
   req->length = length;
@@ -28,17 +39,6 @@ fsctl_lock (uv_loop_t *loop, fsctl_lock_t *req, uv_os_fd_t fd, uint64_t offset, 
   req->req.data = (void *) req;
 
   return uv_queue_work(loop, &req->req, fsctl__lock_work, fsctl__lock_after_work);
-}
-
-int
-fsctl_try_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type) {
-  int err = fsctl__try_lock(fd, offset, length, type);
-
-  if (err == UV_EACCES || err == UV_EAGAIN || err == UV_EBUSY) {
-    err = UV_EAGAIN;
-  }
-
-  return err;
 }
 
 int

--- a/src/win.c
+++ b/src/win.c
@@ -6,10 +6,10 @@
 #include "platform.h"
 
 int
-fsctl__lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type) {
+fsctl__try_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type) {
   if (length == 0) length = SIZE_MAX;
 
-  DWORD flags = 0;
+  DWORD flags = LOCKFILE_FAIL_IMMEDIATELY;
 
   if (type == FSCTL_WRLOCK) flags |= LOCKFILE_EXCLUSIVE_LOCK;
 
@@ -32,10 +32,10 @@ fsctl__lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t ty
 }
 
 int
-fsctl__try_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type) {
+fsctl__wait_for_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type) {
   if (length == 0) length = SIZE_MAX;
 
-  DWORD flags = LOCKFILE_FAIL_IMMEDIATELY;
+  DWORD flags = 0;
 
   if (type == FSCTL_WRLOCK) flags |= LOCKFILE_EXCLUSIVE_LOCK;
 

--- a/test/fixture/lock.mjs
+++ b/test/fixture/lock.mjs
@@ -1,13 +1,13 @@
 import { open } from 'fs/promises'
 import minimist from 'minimist'
-import { lock, tryLock } from '../../index.js'
+import { lock, waitForLock } from '../../index.js'
 
 const argv = minimist(process.argv.slice(2), {
-  boolean: ['exclusive'],
+  boolean: ['shared'],
   string: ['mode', 'offset', 'length'],
   default: {
-    mode: 'r',
-    exclusive: false,
+    mode: 'a+',
+    shared: false,
     offset: 0,
     length: 0
   }
@@ -18,16 +18,16 @@ const offset = parseInt(argv.offset, 10)
 const length = parseInt(argv.length, 10)
 
 const options = {
-  exclusive: argv.exclusive
+  shared: argv.shared
 }
 
 const file = await open(argv._[0], argv.mode)
 
-if (!tryLock(file.fd, offset, length, options)) {
+if (!lock(file.fd, offset, length, options)) {
   process.send({ granted: false })
 }
 
-await lock(file.fd, offset, length, options)
+await waitForLock(file.fd, offset, length, options)
 
 process.send({ granted: true })
 

--- a/test/fixture/lock.mjs
+++ b/test/fixture/lock.mjs
@@ -1,6 +1,6 @@
 import { open } from 'fs/promises'
 import minimist from 'minimist'
-import { lock, waitForLock } from '../../index.js'
+import { tryLock, waitForLock } from '../../index.js'
 
 const argv = minimist(process.argv.slice(2), {
   boolean: ['shared'],
@@ -23,7 +23,7 @@ const options = {
 
 const file = await open(argv._[0], argv.mode)
 
-if (!lock(file.fd, offset, length, options)) {
+if (!tryLock(file.fd, offset, length, options)) {
   process.send({ granted: false })
 }
 

--- a/test/lock.mjs
+++ b/test/lock.mjs
@@ -2,7 +2,7 @@ import test from 'brittle'
 import { fork } from 'child_process'
 import { open } from 'fs/promises'
 import { temporaryFile } from 'tempy'
-import { tryLock, unlock } from '../index.js'
+import { lock, unlock } from '../index.js'
 
 const isWindows = process.platform === 'win32'
 
@@ -12,12 +12,12 @@ test('2 exclusive locks, same fd', async (t) => {
   const handle = await open(file, 'w+')
   t.teardown(() => handle.close())
 
-  t.ok(tryLock(handle.fd, { exclusive: true }), 'lock granted')
+  t.ok(lock(handle.fd), 'lock granted')
 
   if (isWindows) {
-    t.absent(tryLock(handle.fd, { exclusive: true }), 'lock denied')
+    t.absent(lock(handle.fd), 'lock denied')
   } else {
-    t.ok(tryLock(handle.fd, { exclusive: true }), 'lock granted')
+    t.ok(lock(handle.fd), 'lock granted')
   }
 })
 
@@ -30,8 +30,8 @@ test('2 exclusive locks, separate fd', async (t) => {
   const b = await open(file, 'w+')
   t.teardown(() => b.close())
 
-  t.ok(tryLock(a.fd, { exclusive: true }), 'lock granted')
-  t.absent(tryLock(b.fd, { exclusive: true }), 'lock denied')
+  t.ok(lock(a.fd), 'lock granted')
+  t.absent(lock(b.fd), 'lock denied')
 })
 
 test('2 shared locks + 1 exclusive lock, same fd', async (t) => {
@@ -40,13 +40,13 @@ test('2 shared locks + 1 exclusive lock, same fd', async (t) => {
   const handle = await open(file, 'w+')
   t.teardown(() => handle.close())
 
-  t.ok(tryLock(handle.fd), 'lock granted')
-  t.ok(tryLock(handle.fd), 'lock granted')
+  t.ok(lock(handle.fd, { shared: true }), 'lock granted')
+  t.ok(lock(handle.fd, { shared: true }), 'lock granted')
 
   if (isWindows) {
-    t.absent(tryLock(handle.fd, { exclusive: true }), 'lock denied')
+    t.absent(lock(handle.fd), 'lock denied')
   } else {
-    t.ok(tryLock(handle.fd, { exclusive: true }), 'lock granted')
+    t.ok(lock(handle.fd), 'lock granted')
   }
 })
 
@@ -62,15 +62,15 @@ test('2 shared locks + 1 exclusive lock, separate fd', async (t) => {
   const c = await open(file, 'w+')
   t.teardown(() => c.close())
 
-  t.ok(tryLock(a.fd), 'lock granted')
-  t.ok(tryLock(b.fd), 'lock granted')
+  t.ok(lock(a.fd, { shared: true }), 'lock granted')
+  t.ok(lock(b.fd, { shared: true }), 'lock granted')
 
-  t.absent(tryLock(c.fd, { exclusive: true }), 'lock denied')
+  t.absent(lock(c.fd), 'lock denied')
 
   unlock(a.fd)
   unlock(b.fd)
 
-  t.ok(tryLock(c.fd, { exclusive: true }), 'lock granted')
+  t.ok(lock(c.fd), 'lock granted')
 })
 
 test('2 shared locks + 1 exclusive lock, separate process', async (t) => {
@@ -80,8 +80,14 @@ test('2 shared locks + 1 exclusive lock, separate process', async (t) => {
   const file = temporaryFile()
   const handle = await open(file, 'w+')
 
-  const p1 = fork('test/fixture/lock.mjs', [file])
-  const p2 = fork('test/fixture/lock.mjs', [file])
+  const p1 = fork('test/fixture/lock.mjs', [file,
+    '--mode', 'r',
+    '--shared'
+  ])
+  const p2 = fork('test/fixture/lock.mjs', [file,
+    '--mode', 'r',
+    '--shared'
+  ])
 
   p1.on('message', (message) => {
     shared.alike(message, { granted: true }, 'lock granted')
@@ -96,10 +102,7 @@ test('2 shared locks + 1 exclusive lock, separate process', async (t) => {
   const deny = t.test('deny exclusive lock')
   deny.plan(1)
 
-  const p3 = fork('test/fixture/lock.mjs', [file,
-    '--mode', 'a+',
-    '--exclusive'
-  ])
+  const p3 = fork('test/fixture/lock.mjs', [file])
 
   p3.once('message', (message) => {
     deny.alike(message, { granted: false }, 'lock denied')
@@ -137,13 +140,13 @@ test('lock is released on file close', async (t) => {
   const b = await open(file, 'w+')
   t.teardown(() => b.close())
 
-  t.ok(tryLock(a.fd, { exclusive: true }), 'lock granted')
+  t.ok(lock(a.fd), 'lock granted')
 
-  t.absent(tryLock(b.fd), 'lock denied')
+  t.absent(lock(b.fd), 'lock denied')
 
   await t.execution(a.close(), 'file closed, lock released')
 
-  t.ok(tryLock(b.fd), 'lock granted')
+  t.ok(lock(b.fd), 'lock granted')
 })
 
 test('lock is not released on unrelated file close', async (t) => {
@@ -157,9 +160,9 @@ test('lock is not released on unrelated file close', async (t) => {
   const c = await open(file, 'w+')
   t.teardown(() => c.close())
 
-  t.ok(tryLock(a.fd, { exclusive: true }), 'lock granted')
+  t.ok(lock(a.fd), 'lock granted')
 
   await t.execution(b.close(), 'file closed, lock intact')
 
-  t.absent(tryLock(c.fd), 'lock denied')
+  t.absent(lock(c.fd), 'lock denied')
 })


### PR DESCRIPTION
This makes the upgrade path from v1 to v3 simpler for places that vendor `fsctl`.