### PR TITLE
Implement path swapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ On macOS, the hole must be aligned to block boundaries as the call will otherwis
 
 Mark a file as sparse. On Windows, this operation is required before holes can be punched in the file. On other systems, this operation has no effect.
 
+#### `await fsctl.swap(from, to)`
+
+Swap the paths `from` and `to`, making `from` assume the identity of `to` and `to` assume the identity of `from`.
+
+On macOS and Linux, the swap is performed atomically.
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Mark a file as sparse. On Windows, this operation is required before holes can b
 
 Swap the paths `from` and `to`, making `from` assume the identity of `to` and `to` assume the identity of `from`.
 
-On Windows, the swap is performed by first moving `to` to a swapfile, then moving `from` to `to`, and finally moving the swapfile to `from`.
+On Windows, the swap is performed by first moving `to` to a temporary path, then moving `from` to `to`, and finally moving the temporary path to `from`.
 
 On macOS and Linux, the swap is performed atomically.
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Mark a file as sparse. On Windows, this operation is required before holes can b
 
 Swap the paths `from` and `to`, making `from` assume the identity of `to` and `to` assume the identity of `from`.
 
+On Windows, the swap is performed by first moving `to` to a swapfile, then moving `from` to `to`, and finally moving the swapfile to `from`.
+
 On macOS and Linux, the swap is performed atomically.
 
 ## License

--- a/binding.c
+++ b/binding.c
@@ -29,6 +29,14 @@ typedef struct {
   napi_ref cb;
 } fsctl_napi_sparse_t;
 
+typedef struct {
+  fsctl_swap_t req;
+
+  napi_env env;
+  napi_ref ctx;
+  napi_ref cb;
+} fsctl_napi_swap_t;
+
 static void
 on_fsctl_lock (fsctl_lock_t *req, int status) {
   fsctl_napi_lock_t *r = (fsctl_napi_lock_t *) req;
@@ -108,6 +116,36 @@ on_fsctl_sparse (fsctl_sparse_t *req, int status) {
 
   napi_delete_reference(env, r->ctx);
   napi_delete_reference(env, r->cb);
+}
+
+static void
+on_fsctl_swap (fsctl_swap_t *req, int status) {
+  fsctl_napi_swap_t *r = (fsctl_napi_swap_t *) req;
+
+  napi_env env = r->env;
+
+  napi_handle_scope scope;
+  napi_open_handle_scope(env, &scope);
+
+  napi_value argv[1];
+
+  napi_value ctx;
+  napi_get_reference_value(env, r->ctx, &ctx);
+
+  napi_value callback;
+  napi_get_reference_value(env, r->cb, &callback);
+
+  napi_create_int32(env, req->result, &argv[0]);
+
+  NAPI_MAKE_CALLBACK(env, NULL, ctx, callback, 1, argv, NULL);
+
+  napi_close_handle_scope(env, scope);
+
+  napi_delete_reference(env, r->ctx);
+  napi_delete_reference(env, r->cb);
+
+  free((char *) req->from_path);
+  free((char *) req->to_path);
 }
 
 NAPI_METHOD(fsctl_napi_try_lock) {
@@ -217,14 +255,41 @@ NAPI_METHOD(fsctl_napi_sparse) {
   NAPI_RETURN_INT32(err);
 }
 
+NAPI_METHOD(fsctl_napi_swap) {
+  NAPI_ARGV(5)
+  NAPI_ARGV_BUFFER_CAST(fsctl_napi_swap_t *, req, 0)
+  NAPI_ARGV_UTF8_MALLOC(from_path, 1)
+  NAPI_ARGV_UTF8_MALLOC(to_path, 2)
+
+  req->env = env;
+
+  napi_create_reference(env, argv[3], 1, &(req->ctx));
+  napi_create_reference(env, argv[4], 1, &(req->cb));
+
+  uv_loop_t *loop;
+  napi_get_uv_event_loop(env, &loop);
+
+  int err = fsctl_swap(
+    loop,
+    (fsctl_swap_t *) req,
+    from_path,
+    to_path,
+    on_fsctl_swap
+  );
+
+  NAPI_RETURN_INT32(err);
+}
+
 NAPI_INIT() {
   NAPI_EXPORT_SIZEOF(fsctl_napi_lock_t)
   NAPI_EXPORT_SIZEOF(fsctl_napi_punch_hole_t)
   NAPI_EXPORT_SIZEOF(fsctl_napi_sparse_t)
+  NAPI_EXPORT_SIZEOF(fsctl_napi_swap_t)
 
   NAPI_EXPORT_FUNCTION(fsctl_napi_try_lock)
   NAPI_EXPORT_FUNCTION(fsctl_napi_wait_for_lock)
   NAPI_EXPORT_FUNCTION(fsctl_napi_unlock)
   NAPI_EXPORT_FUNCTION(fsctl_napi_punch_hole)
   NAPI_EXPORT_FUNCTION(fsctl_napi_sparse)
+  NAPI_EXPORT_FUNCTION(fsctl_napi_swap)
 }

--- a/include/fsctl.h
+++ b/include/fsctl.h
@@ -13,12 +13,16 @@ extern "C" {
 typedef struct fsctl_lock_s fsctl_lock_t;
 typedef struct fsctl_punch_hole_s fsctl_punch_hole_t;
 typedef struct fsctl_sparse_s fsctl_sparse_t;
+typedef struct fsctl_swap_s fsctl_swap_t;
+typedef struct fsctl_swap_at_s fsctl_swap_at_t;
 
 // Callbacks
 
 typedef void (*fsctl_lock_cb)(fsctl_lock_t *req, int status);
 typedef void (*fsctl_punch_hole_cb)(fsctl_punch_hole_t *req, int status);
 typedef void (*fsctl_sparse_cb)(fsctl_sparse_t *req, int status);
+typedef void (*fsctl_swap_cb)(fsctl_swap_t *req, int status);
+typedef void (*fsctl_swap_at_cb)(fsctl_swap_at_t *req, int status);
 
 typedef enum {
   FSCTL_RDLOCK = 1,
@@ -66,6 +70,34 @@ struct fsctl_sparse_s {
   void *data;
 };
 
+struct fsctl_swap_s {
+  uv_work_t req;
+
+  const char *from_path;
+  const char *to_path;
+
+  fsctl_swap_cb cb;
+
+  int result;
+
+  void *data;
+};
+
+struct fsctl_swap_at_s {
+  uv_work_t req;
+
+  uv_os_fd_t from_fd;
+  const char *from_path;
+  uv_os_fd_t to_fd;
+  const char *to_path;
+
+  fsctl_swap_at_cb cb;
+
+  int result;
+
+  void *data;
+};
+
 int
 fsctl_try_lock (uv_os_fd_t fd, uint64_t offset, size_t length, fsctl_lock_type_t type);
 
@@ -80,6 +112,12 @@ fsctl_punch_hole (uv_loop_t *loop, fsctl_punch_hole_t *req, uv_os_fd_t fd, uint6
 
 int
 fsctl_sparse (uv_loop_t *loop, fsctl_sparse_t *req, uv_os_fd_t fd, fsctl_sparse_cb cb);
+
+int
+fsctl_swap (uv_loop_t *loop, fsctl_swap_t *req, const char *from_path, const char *to_path, fsctl_swap_cb cb);
+
+int
+fsctl_swap_at (uv_loop_t *loop, fsctl_swap_at_t *req, uv_os_fd_t from_fd, const char *from_path, uv_os_fd_t to_fd, const char *to_path, fsctl_swap_at_cb cb);
 
 #ifdef __cplusplus
 }

--- a/index.js
+++ b/index.js
@@ -118,6 +118,26 @@ exports.sparse = function sparse (fd) {
   return promise
 }
 
+exports.swap = function swap (from, to) {
+  const req = Buffer.alloc(binding.sizeof_fsctl_napi_swap_t)
+  const ctx = {
+    req,
+    resolve: null,
+    reject: null
+  }
+
+  const promise = new Promise((resolve, reject) => {
+    ctx.resolve = resolve
+    ctx.reject = reject
+  })
+
+  const errno = binding.fsctl_napi_swap(req, from, to, ctx, onwork)
+
+  if (errno < 0) return Promise.reject(toError(errno))
+
+  return promise
+}
+
 function toError (errno) {
   const [code, msg] = util.getSystemErrorMap().get(errno)
 

--- a/src/linux.c
+++ b/src/linux.c
@@ -14,3 +14,15 @@ fsctl__punch_hole (uv_os_fd_t fd, uint64_t offset, size_t length) {
 
   return res == -1 ? uv_translate_sys_error(errno) : res;
 }
+
+int
+fsctl__swap (const char *from_path, const char *to_path) {
+  return fsctl__swap_at(AT_FDCWD, from_path, AT_FDCWD, to_path);
+}
+
+int
+fsctl__swap_at (uv_os_fd_t from_fd, const char *from_path, uv_os_fd_t to_fd, const char *to_path) {
+  int res = renameat2(from_fd, from_path, to_fd, to_path, RENAME_EXCHANGE);
+
+  return res == -1 ? uv_translate_sys_error(errno) : res;
+}

--- a/src/linux.c
+++ b/src/linux.c
@@ -16,11 +16,6 @@ fsctl__punch_hole (uv_os_fd_t fd, uint64_t offset, size_t length) {
 }
 
 int
-fsctl__swap (const char *from_path, const char *to_path) {
-  return fsctl__swap_at(AT_FDCWD, from_path, AT_FDCWD, to_path);
-}
-
-int
 fsctl__swap_at (uv_os_fd_t from_fd, const char *from_path, uv_os_fd_t to_fd, const char *to_path) {
   int res = renameat2(from_fd, from_path, to_fd, to_path, RENAME_EXCHANGE);
 

--- a/src/mac.c
+++ b/src/mac.c
@@ -21,13 +21,6 @@ fsctl__punch_hole (uv_os_fd_t fd, uint64_t offset, size_t length) {
 }
 
 int
-fsctl__swap (const char *from_path, const char *to_path) {
-  int res = renamex_np(from_path, to_path, RENAME_SWAP);
-
-  return res == -1 ? uv_translate_sys_error(errno) : res;
-}
-
-int
 fsctl__swap_at (uv_os_fd_t from_fd, const char *from_path, uv_os_fd_t to_fd, const char *to_path) {
   int res = renameatx_np(from_fd, from_path, to_fd, to_path, RENAME_SWAP);
 

--- a/src/mac.c
+++ b/src/mac.c
@@ -19,3 +19,17 @@ fsctl__punch_hole (uv_os_fd_t fd, uint64_t offset, size_t length) {
 
   return res == -1 ? uv_translate_sys_error(errno) : res;
 }
+
+int
+fsctl__swap (const char *from_path, const char *to_path) {
+  int res = renamex_np(from_path, to_path, RENAME_SWAP);
+
+  return res == -1 ? uv_translate_sys_error(errno) : res;
+}
+
+int
+fsctl__swap_at (uv_os_fd_t from_fd, const char *from_path, uv_os_fd_t to_fd, const char *to_path) {
+  int res = renameatx_np(from_fd, from_path, to_fd, to_path, RENAME_SWAP);
+
+  return res == -1 ? uv_translate_sys_error(errno) : res;
+}

--- a/src/platform.h
+++ b/src/platform.h
@@ -21,4 +21,10 @@ fsctl__punch_hole (uv_os_fd_t fd, uint64_t offset, size_t length);
 int
 fsctl__sparse (uv_os_fd_t fd);
 
+int
+fsctl__swap (const char *from_path, const char *to_path);
+
+int
+fsctl__swap_at (uv_os_fd_t from_fd, const char *from_path, uv_os_fd_t to_fd, const char *to_path);
+
 #endif // FSCTL_PLATFORM_H

--- a/src/posix.c
+++ b/src/posix.c
@@ -37,3 +37,8 @@ int
 fsctl__sparse (uv_os_fd_t fd) {
   return 0;
 }
+
+int
+fsctl__swap (const char *from_path, const char *to_path) {
+  return fsctl__swap_at(AT_FDCWD, from_path, AT_FDCWD, to_path);
+}

--- a/src/shared.c
+++ b/src/shared.c
@@ -93,3 +93,53 @@ fsctl_sparse (uv_loop_t *loop, fsctl_sparse_t *req, uv_os_fd_t fd, fsctl_sparse_
 
   return uv_queue_work(loop, &req->req, fsctl__sparse_work, fsctl__sparse_after_work);
 }
+
+static void
+fsctl__swap_work (uv_work_t *req) {
+  fsctl_swap_t *r = (fsctl_swap_t *) req->data;
+
+  r->result = fsctl__swap(r->from_path, r->to_path);
+}
+
+static void
+fsctl__swap_after_work (uv_work_t *req, int status) {
+  fsctl_swap_t *r = (fsctl_swap_t *) req->data;
+
+  if (r->cb) r->cb(r, r->result);
+}
+
+int
+fsctl_swap (uv_loop_t *loop, fsctl_swap_t *req, const char *from_path, const char *to_path, fsctl_swap_cb cb) {
+  req->from_path = from_path;
+  req->to_path = to_path;
+  req->cb = cb;
+  req->req.data = (void *) req;
+
+  return uv_queue_work(loop, &req->req, fsctl__swap_work, fsctl__swap_after_work);
+}
+
+static void
+fsctl__swap_at_work (uv_work_t *req) {
+  fsctl_swap_at_t *r = (fsctl_swap_at_t *) req->data;
+
+  r->result = fsctl__swap_at(r->from_fd, r->from_path, r->to_fd, r->to_path);
+}
+
+static void
+fsctl__swap_at_after_work (uv_work_t *req, int status) {
+  fsctl_swap_at_t *r = (fsctl_swap_at_t *) req->data;
+
+  if (r->cb) r->cb(r, r->result);
+}
+
+int
+fsctl_swap_at (uv_loop_t *loop, fsctl_swap_at_t *req, uv_os_fd_t from_fd, const char *from_path, uv_os_fd_t to_fd, const char *to_path, fsctl_swap_at_cb cb) {
+  req->from_fd = from_fd;
+  req->from_path = from_path;
+  req->to_fd = to_fd;
+  req->to_path = to_path;
+  req->cb = cb;
+  req->req.data = (void *) req;
+
+  return uv_queue_work(loop, &req->req, fsctl__swap_at_work, fsctl__swap_at_after_work);
+}

--- a/src/win.c
+++ b/src/win.c
@@ -122,3 +122,13 @@ fsctl__sparse (uv_os_fd_t fd) {
 
   return res ? 0 : uv_translate_sys_error(GetLastError());
 }
+
+int
+fsctl__swap (const char *from_path, const char *to_path) {
+  return UV_ENOSYS;
+}
+
+int
+fsctl__swap_at (uv_os_fd_t from_fd, const char *from_path, uv_os_fd_t to_fd, const char *to_path) {
+  return UV_ENOSYS;
+}

--- a/test/swap.mjs
+++ b/test/swap.mjs
@@ -5,9 +5,7 @@ import { temporaryFile, temporaryDirectory } from 'tempy'
 
 import { swap } from '../index.js'
 
-const isWindows = process.platform === 'win32'
-
-test('swap files', { skip: isWindows }, async (t) => {
+test('swap files', async (t) => {
   const a = temporaryFile()
   const b = temporaryFile()
 
@@ -20,7 +18,7 @@ test('swap files', { skip: isWindows }, async (t) => {
   t.is(await readFile(b, 'utf8'), 'a')
 })
 
-test('swap directories', { skip: isWindows }, async (t) => {
+test('swap directories', async (t) => {
   const a = temporaryDirectory()
   const b = temporaryDirectory()
 
@@ -33,7 +31,7 @@ test('swap directories', { skip: isWindows }, async (t) => {
   t.is(await readFile(join(b, 'a'), 'utf8'), 'a')
 })
 
-test('swap file and directory', { skip: isWindows }, async (t) => {
+test('swap file and directory', async (t) => {
   const a = temporaryDirectory()
   const b = temporaryFile()
 

--- a/test/swap.mjs
+++ b/test/swap.mjs
@@ -1,0 +1,47 @@
+import test from 'brittle'
+import { join } from 'path'
+import { writeFile, readFile } from 'fs/promises'
+import { temporaryFile, temporaryDirectory } from 'tempy'
+
+import { swap } from '../index.js'
+
+const isWindows = process.platform === 'win32'
+
+test('swap files', { skip: isWindows }, async (t) => {
+  const a = temporaryFile()
+  const b = temporaryFile()
+
+  await writeFile(a, 'a')
+  await writeFile(b, 'b')
+
+  await swap(a, b)
+
+  t.is(await readFile(a, 'utf8'), 'b')
+  t.is(await readFile(b, 'utf8'), 'a')
+})
+
+test('swap directories', { skip: isWindows }, async (t) => {
+  const a = temporaryDirectory()
+  const b = temporaryDirectory()
+
+  await writeFile(join(a, 'a'), 'a')
+  await writeFile(join(b, 'b'), 'b')
+
+  await swap(a, b)
+
+  t.is(await readFile(join(a, 'b'), 'utf8'), 'b')
+  t.is(await readFile(join(b, 'a'), 'utf8'), 'a')
+})
+
+test('swap file and directory', { skip: isWindows }, async (t) => {
+  const a = temporaryDirectory()
+  const b = temporaryFile()
+
+  await writeFile(join(a, 'a'), 'a')
+  await writeFile(b, 'b')
+
+  await swap(a, b)
+
+  t.is(await readFile(a, 'utf8'), 'b')
+  t.is(await readFile(join(b, 'a'), 'utf8'), 'a')
+})


### PR DESCRIPTION
This PR implements path swapping on Windows, Linux, and macOS. On Linux and macOS, path swapping is performed atomically using the available system calls. On Windows, path swapping is instead performed as a best-effort series of 3 `MoveFile()` calls for lack of an atomic system call.